### PR TITLE
fix(profiles): checkbox not checked

### DIFF
--- a/src/pages/profiles/components/PortfolioGallery.jsx
+++ b/src/pages/profiles/components/PortfolioGallery.jsx
@@ -125,6 +125,7 @@ class PortfolioGallery extends Component {
                         row.thumbnail && row.thumbnail.photo
                           ? {
                               source: `/api/image/${row.thumbnail.photo.id}`,
+                              id: row.id,
                             }
                           : null
                       }


### PR DESCRIPTION
# Description

Fixes issue of profile gallery image not checked when selected.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which does not adds functionality)
- [ ] Chore (changes that does not modify any code in `./src` or `./server`)
- [ ] This change requires a documentation update

## Screenshot (for UI changes)

Delete this section if this PR has no UI changes

## Checklist:

- [ ] My pull request title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] I have installed and run the [pre-commit](https://pre-commit.com/) hook
- [ ] I have started the app locally and inspected my changes are working as intended
- [ ] I have assigned myself as the assignee of this PR and added the relevent labels
